### PR TITLE
fix: maxe shutdown restricted to bot owner

### DIFF
--- a/mybot.js
+++ b/mybot.js
@@ -98,7 +98,7 @@ client.awaitReply = async (message, question, limit = 15000, embed = {}) => {
   if (message.content.toLowerCase().startsWith(config.prefix + "shutdown")) {
       message.reply('The bot will now shut down.\n'+ 'Confirm with a thumb up or deny with a thumb down.');
       //check if no perm
-      if(!message.member.hasPermission("ADMINISTRATOR")){
+      if(message.author.id !== config.ownerID){
       return message.reply("You don't have permission to do that!");
       }              
       // Reacts so the user only have to click the emojis


### PR DESCRIPTION
Shutting down the bot should be an action reserved to bot owner (and admins if there are), not to server admins who are not related to the bot. 